### PR TITLE
Add fog-softlayer to orgs.js

### DIFF
--- a/orgs.js
+++ b/orgs.js
@@ -46,6 +46,8 @@
     	{"name": "ibm-rtvs",
     	  "type": "user"},
     	{"name": "bigfix",
-    	  "type": "org"}
+    	  "type": "org"},
+    	{"name": "fog/fog-softlayer",
+    	  "type": "repo"}
     ];
     


### PR DESCRIPTION
Just noticed that [fog-softlayer](https://github.com/fog/fog-softlayer/) wasn't in here.  It's hosted under the [fog](https://github.com/fog/) org, but is officially IBM approved/sponsored (I'm the primary developer/maintainer of it and I'm an IBMer).