### PR TITLE
Use https cdnjs version of bootstrap stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 <title>IBM @ Github</title>
 
-<link href="http://getbootstrap.com/dist/css/bootstrap.css" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
 
 <link href="http://getbootstrap.com/examples/jumbotron/jumbotron.css" rel="stylesheet">
 <link href="./css/style.css" rel="stylesheet">


### PR DESCRIPTION
This allows the basic stylesheet to load (github.io defaults to https). You still need to either vendor the carousel.css or find an https version of it.