### PR TITLE
Added org page for IBM-DBWKL

### DIFF
--- a/orgs.js
+++ b/orgs.js
@@ -66,5 +66,7 @@
         {"name": "ibm-research",
           "type": "org"},
         {"name": "digexp",
+          "type": "org"},
+        {"name": "IBM-DBWKL",
           "type": "org"}
     ];


### PR DESCRIPTION
IBM-DBWKL contains a project that is used to create workload for the OMEGAMON XE for DB2 project but can be used in other scenarios as well.