### PR TITLE
Make Search field not run into text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -275,17 +275,17 @@ background:url(../imgs/news.jpg) no-repeat;
 
 #wrapper .java
 {
-	//border-top: 4px solid #510FAD;
+	/* border-top: 4px solid #510FAD; */
 }
 
 #wrapper .ruby
 {
-	//border-top: 4px solid #33CCCC;
+	/* border-top: 4px solid #33CCCC; */
 }
 
 #wrapper .javascript
 {
-	//border-top: 4px solid #FFBE40;
+	/* border-top: 4px solid #FFBE40; */
 }
 
 .section-title
@@ -294,6 +294,16 @@ background:url(../imgs/news.jpg) no-repeat;
 	text-transform: uppercase;
 	position: relative;
 	margin: 3px;
+}
+
+label.search span
+{
+	text-transform: uppercase;
+	float: left;
+	padding-top: 6px;
+	padding-left: 19px;
+	font-weight: 700;
+	padding-right: .25em;
 }
 
 .section-title .title

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@ ga('send', 'pageview');
           <div class="row">
             <div class="col-sm-12 col-md-12 col-lg-12">
              <div id="wrapper">
-              <label for="search" class="col-lg-4 control-label search" style=""><span style="float:left; padding-top:6px; padding-left: 19px;font-weight: 700">SEARCH</span> <input type="search" id="search" class="search-query span3 filter input-medium" placeholder="Our Repos..."></label>
+              <label for="search" class="col-lg-4 control-label search" style=""><span>Search</span> <input type="search" id="search" class="search-query span3 filter input-medium" placeholder="Our Repos..."></label>
               
               <div id="repos" class="columns collapse-group">
                


### PR DESCRIPTION
Medium:
* add padding on right of search field’s label. Otherwise highlight runs into the word SEARCH

<img width="239" alt="searchrun" src="https://cloud.githubusercontent.com/assets/855219/14889448/b4668b6a-0d13-11e6-9337-52c5df804457.png">

Minor:
* move styles from search label off to css
* use text transform for uppercase (uppercase-as-a-style). 
* fix some bad comments in css