### PR TITLE
fix quarks-edge, add check for repo type

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,10 @@ ga('send', 'pageview');
 	   // all in all, pretty safe to expose this here.
 
        // there are three supported request types: org, user and repo. Syntax differs.
+       if((orgs.type !== 'org') && (orgs.type !== 'user') && (orgs.type !== 'repo')) {
+       	  console.log('** Unknown type “'+orgs.type+'” for org “'+org+'” — check “orgs.js” for typo.'); 
+       	  return;
+       }
        var uri = "https://api.github.com/"+orgs.type+"s/"+org + reposcmd
        + "?per_page=1000"
        + "&client_id=1bafa09b6086eec7afb4"

--- a/orgs.js
+++ b/orgs.js
@@ -112,7 +112,7 @@
         {"name": "djwillia/solo5",
         "type": "repo"},
         {"name": "quarks-edge",
-         "type": "orgs"},
+         "type": "org"},
         {"name": "jamiejennings/rosie-pattern-language",
          "type": "repo"},
         {"name": "openblockchain",


### PR DESCRIPTION
* quarks-edge was missed as an org because of a typo in orgs.js
* verify org.js has a valid type, otherwise print an error.