### PR TITLE
Add IBM Watson Personality Insights organization

### DIFF
--- a/orgs.js
+++ b/orgs.js
@@ -390,5 +390,7 @@
         {"name": "strongloop/loopback-example-connector",
           "type": "repo"},
         {"name": "strongloop/loopback-example-storage",
-          "type": "repo"}
+          "type": "repo"},
+        {"name": "personality-insights",
+          "type": "org"},
     ];


### PR DESCRIPTION
We are running an organization for IBM Watson Personality Insights at http://github.com/personality-insights . It includes some components present in Personality Insights' demo and will include more in a near future.