### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 Portal for IBM open source at GitHub http://ibm.github.io.
 
-Visit us at https://hub.jazz.net/project/kellrman/IBMGitHubOrg.
-
 [Contact us](mailto:hub@jazz.net)


### PR DESCRIPTION
Link to https://hub.jazz.net/project/kellrman/IBMGitHubOrg/overview was deprecated.  Removed the bad link from Readme.