### PR TITLE
"Bluemix Devops Experience" hyperlink updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ ga('send', 'pageview');
     <div class="container">
       <h1>IBM Open Source at GitHub</h1>
       <div class="leadspace-buttons">
-        <a href="http://hub.jazz.net/" data-analytics-category="Leadspace buttons" data-analytics-action="JazzHub">
+        <a href="https://console.bluemix.net/devops/try-toolchains" data-analytics-category="Leadspace buttons" data-analytics-action="JazzHub">
           <p class="btn btn-primary btn-lg btn-custom-jazz">Enhance your GitHub experience with <b>Bluemix DevOps Services</b>
           </p>
          </a>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ ga('send', 'pageview');
     <div class="container">
       <h1>IBM Open Source at GitHub</h1>
       <div class="leadspace-buttons">
-        <a href="https://console.bluemix.net/devops/try-toolchains" data-analytics-category="Leadspace buttons" data-analytics-action="JazzHub">
+        <a href="https://console.bluemix.net/devops/getting-started" data-analytics-category="Leadspace buttons" data-analytics-action="JazzHub">
           <p class="btn btn-primary btn-lg btn-custom-jazz">Enhance your GitHub experience with <b>Bluemix DevOps Services</b>
           </p>
          </a>


### PR DESCRIPTION
"Bluemix Devops Experience" div had link http://hub.jazz.net/ which is redirected to https://console.bluemix.net/devops/try-toolchains. So update link directly to https://console.bluemix.net/devops/try-toolchains.