### PR TITLE
Screen overflow on mobile screens issue solved

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -31,6 +31,11 @@ src: url('/fonts/Lubalin/LubalinGraphStd-Medium.otf') format('opentype');
 	font-family: 'Helvetica-Neue-Md';
 	src: url('/fonts/helvneue/HelveticaNeueLTStd-Md.otf') format('opentype');
 }
+@media only screen and (max-width:768px){
+	html{
+		overflow-x: hidden;
+	}
+}
 
 .jumbotron
 {


### PR DESCRIPTION
When we swipe left, their was  blank space shown due to overflow in x-direction.