### PR TITLE
Added missing changes for centering search bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -160,7 +160,7 @@ font-family: Helvetica, Arial, Tahoma, sans-serif;
 {
 	float:none;
 	font-family: 'Helvetica';
-	padding-right: 0;
+	padding: 2px;
 	margin: auto;
 	display: table;
 }
@@ -351,15 +351,20 @@ label.search span
 	text-transform: uppercase;
 	float: left;
 	padding-top: 6px;
-	padding-left: 19px;
+	padding-left: 1px;
 	font-weight: 700;
 	padding-right: .25em;
 }
 @media screen and (max-width:768px){
-	label.search span{
+	
+	label.search span {
 		float: none;
 		margin: auto;
 		display: table;
+	}
+	
+	label.search { 
+		width: 100%; 
 	}
 }
 


### PR DESCRIPTION
_This pull request is an addition to pull request from #85_ 

This will fix mobile view of search box:

- it does make search bar wider

- it does center <span> content over search bar

## **Now on live site:** 

![image](https://user-images.githubusercontent.com/10914774/32210827-0539b252-be10-11e7-9321-4c1221869c6f.png)

## **After my change:**

![snapshot3](https://user-images.githubusercontent.com/10914774/32159997-23aef348-bd50-11e7-9023-d60ecf1c6e5e.png)