### PR TITLE
Added feature to select more or less repos

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,10 +27,28 @@
 	src: url('/fonts/helvneue/HelveticaNeueLTStd-Md.otf') format('opentype');
 }
 
+.navigation {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  
+  -webkit-flex-flow: row wrap;
+  justify-content: space-around;
+}
+
 .show_less {
-    float: left; 
-    width: 25%; 
+    flex-grow: 1;
+    order: 1;
+    float: left;
+    width: 25%;
     text-align: center;
+    margin-left: -2.2% !important;
 }
 
 .show_less a {
@@ -38,6 +56,8 @@
 }
 
 .show_more {
+    flex-grow: 1;
+    order: 3;
     float: right; 
     width: 25%; 
     text-align: center;
@@ -47,9 +67,29 @@
     margin-left: auto !important;
 }
 
-@media screen and (max-width:768px) {
-    .show_less, .show_more {
+@media screen and (max-width:767px) {
+    .show_less {
+        order: 3;
+        float: none;
         margin-top: 5% !important;
+        border-left: 3px solid #f0f0f0;
+        width: 25% !important;
+    }
+    .show_more {
+        order: 2;
+        margin-right: 1em;
+        float: none;
+        border-right: 3px solid #f0f0f0;
+        margin-top: 5% !important;
+    }
+    .search {
+        order: 1;
+    }
+}
+
+@media screen and (max-width:1024px) {
+    .filter {
+        width: 21em !important;
     }
 }
 
@@ -170,10 +210,10 @@ body { /* Double? */
 }
 
 .search {
-	float: none;
+    flex-grow: 2;
+    order: 2;
 	font-family: 'Helvetica';
-	margin: auto;
-	display: table;
+    width: auto;
 }
 
 .nrepos  {
@@ -299,11 +339,13 @@ div.news {
 }
 
 .filter {
-	float: right;
-	padding: 5px;
-	width: 280px;
-	border: 1px solid #b9b9b9;
+    float: none;
+    margin-top: 1.5%;
+    padding: 5px;
+    width: 30em;
+    border: 1px solid #b9b9b9;
     border-radius: 5px;
+
 }
 
 .section {
@@ -337,12 +379,12 @@ div.news {
 }
 
 label.search span {
-	text-transform: uppercase;
-	float: left;
-	padding-top: 6px;
-	padding-left: 1px;
-	font-weight: 700;
-	padding-right: .25em;
+text-transform: uppercase;
+    float: left;
+    padding-top: 15px;
+    /* padding-right: 1px; */
+    font-weight: 700;
+    padding-right: .5em;
 }
 
 @media screen and (max-width:1199px) {
@@ -360,16 +402,14 @@ label.search span {
 		display: table;
 		padding-top: 0px;
 	}
+    label.search {
+    }
 }
 
 @media screen and (max-width:440px) {
 	
 	label.search span {
 		padding-top: 0px;
-	}
-
-	label.search { 
-		width: 80%; 
 	}
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -27,6 +27,32 @@
 	src: url('/fonts/helvneue/HelveticaNeueLTStd-Md.otf') format('opentype');
 }
 
+.show_less {
+    float: left; 
+    width: 25%; 
+    text-align: center;
+}
+
+.show_less a {
+    margin-left: auto !important;
+}
+
+.show_more {
+    float: right; 
+    width: 25%; 
+    text-align: center;
+}
+
+.show_more a {
+    margin-left: auto !important;
+}
+
+@media screen and (max-width:768px) {
+    .show_less, .show_more {
+        margin-top: 5% !important;
+    }
+}
+
 .jumbotron {
 	background: #1b1f30 url(../images/pattern.png) repeat 0 0;
 	color: #fff;

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
                         $item.appendTo(htag);
                         counter++;
                     }
-                    $(".nrepos").text("(" + counter + ") Click 'Show less' to show only 20 repos");
+                    $(".nrepos").text(": " + counter + " shown. Click 'Show less' to show only 20 repos");
                 } else {
                     for (r = 0; r < Math.min(20, allrepos.length); r++) {
                         repo = allrepos[r];
@@ -205,7 +205,7 @@
                         $item.appendTo(htag);
                         counter++;
                     }
-                    $(".nrepos").text("(" + counter + ") Click 'Show more' to see other (" + (allrepos.length - counter) + ") repos");
+                    $(".nrepos").text(": " + counter + " shown. Click 'Show more' to see other " + (allrepos.length - counter) + " repos");
                 }
                 $("#allrepos").collapse({
                     toggle: true

--- a/index.html
+++ b/index.html
@@ -1,123 +1,135 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <!-- saved from url=(0043)http://getbootstrap.com/examples/jumbotron/ -->
 <html lang="en">
 
 <head>
 
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="">
-<meta name="author" content="">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
 
-<link href="https://www.ibm.com/favicon.ico" rel="icon"/>
-<link rel="icon" href="http://ibm.github.io/favicon.ico" type="image/vnd.microsoft.icon" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-<link href="./css/style.css" rel="stylesheet">
+    <link href="https://www.ibm.com/favicon.ico" rel="icon" />
+    <link rel="icon" href="http://ibm.github.io/favicon.ico" type="image/vnd.microsoft.icon" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
+    <link href="./css/style.css" rel="stylesheet">
 
-<title>IBM @ Github</title>
+    <title>IBM @ Github</title>
 
-<script src="//cdn.optimizely.com/js/1141215513.js"></script>
-<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga'); 
+    <script src="//cdn.optimizely.com/js/1141215513.js"></script>
+    <script>
+        (function(i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r;
+            i[r] = i[r] || function() {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+            a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0];
+            a.async = 1;
+            a.src = g;
+            m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-ga('create', 'UA-41146412-2', 'ibm.github.io');
-ga('send', 'pageview');
-</script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-<script>
-$(function() {
+        ga('create', 'UA-41146412-2', 'ibm.github.io');
+        ga('send', 'pageview');
 
-    $('#showallrepos a').click(function(e){
-        var url=$(this).attr('href');
+    </script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script>
+        $(function() {
 
-        window.location.href=url;// ## change url with hash
-        location.reload();       // ## reload page
+            $('#showallrepos a').click(function(e) {
+                var url = $(this).attr('href');
 
-        e.preventDefault();      // ## prevent default click action 
-    })
+                window.location.href = url; // ## change url with hash
+                location.reload(); // ## reload page
 
-})     
-</script>
-  <script>  
-$(function() {
+                e.preventDefault(); // ## prevent default click action 
+            })
 
-    $('#showsomerepos a').click(function(e){
-        history.pushState("", document.title, window.location.pathname + window.location.search);
-        location.reload();
-        e.preventDefault();
-    })
+        })
 
-})     
-</script>
-    
+    </script>
+    <script>
+        $(function() {
+
+            $('#showsomerepos a').click(function(e) {
+                history.pushState("", document.title, window.location.pathname + window.location.search);
+                location.reload();
+                e.preventDefault();
+            })
+
+        })
+
+    </script>
+
 
 </head>
+
 <body>
 
-  <div class="navbar navbar-inverse navbar-fixed-top">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="http://www.ibm.com"><img src="images/ibmneg_white_42x20.png" alt="IBM"></a>
-      <!--a class="navbar-brand" style="float: right" href="http://www.ibm.com/developerworks"><img src="images/dWmark.png" alt="DW"></a-->
-      <a id="dw-nav" class="navbar-brand" style="float: right" href="http://www.ibm.com/developerworks" title="developerWorks"><span class="dw-logo-IBM">IBM</span>&nbsp;<span class="dw-logo-d">d</span><span class="dw-logo-W">W</span></a>
-      <div class="navbar-header">
-      </div>
-    </div>
-  </div>
-
-  <!-- Main jumbotron for a primary marketing message or call to action -->
-  <div class="jumbotron">
-    <div class="container">
-      <h1>IBM Open Source at GitHub</h1>
-      <div class="leadspace-buttons">
-        <a href="https://console.bluemix.net/devops/getting-started" data-analytics-category="Leadspace buttons" data-analytics-action="JazzHub">
-          <p class="btn btn-primary btn-lg btn-custom-jazz">Enhance your GitHub experience with <b>Bluemix DevOps Services</b>
-          </p>
-         </a>
-	     <a href="https://www.bluemix.net/" data-analytics-category="Leadspace buttons" data-analytics-action="BlueMix">
-	       <p class="btn btn-primary btn-lg btn-custom-bm">Deploy your application to <b>Bluemix cloud platform</b>
-           </p>
-	     </a>
-         <a href="http://developer.ibm.com/open" data-analytics-category="Leadspace buttons" data-analytics-action="developerWorks Open">
-           <p class="btn btn-primary btn-lg btn-custom-dw">Engage with IBM Open Source <b>developerWorks Open</b>
-           </p>
-         </a>
+    <div class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="http://www.ibm.com"><img src="images/ibmneg_white_42x20.png" alt="IBM"></a>
+            <!--a class="navbar-brand" style="float: right" href="http://www.ibm.com/developerworks"><img src="images/dWmark.png" alt="DW"></a-->
+            <a id="dw-nav" class="navbar-brand" style="float: right" href="http://www.ibm.com/developerworks" title="developerWorks"><span class="dw-logo-IBM">IBM</span>&nbsp;<span class="dw-logo-d">d</span><span class="dw-logo-W">W</span></a>
+            <div class="navbar-header">
+            </div>
         </div>
-      </div>
     </div>
+
+    <!-- Main jumbotron for a primary marketing message or call to action -->
+    <div class="jumbotron">
         <div class="container">
-          <div class="row">
+            <h1>IBM Open Source at GitHub</h1>
+            <div class="leadspace-buttons">
+                <a href="https://console.bluemix.net/devops/getting-started" data-analytics-category="Leadspace buttons" data-analytics-action="JazzHub">
+                    <p class="btn btn-primary btn-lg btn-custom-jazz">Enhance your GitHub experience with <b>Bluemix DevOps Services</b>
+                    </p>
+                </a>
+                <a href="https://www.bluemix.net/" data-analytics-category="Leadspace buttons" data-analytics-action="BlueMix">
+                    <p class="btn btn-primary btn-lg btn-custom-bm">Deploy your application to <b>Bluemix cloud platform</b>
+                    </p>
+                </a>
+                <a href="http://developer.ibm.com/open" data-analytics-category="Leadspace buttons" data-analytics-action="developerWorks Open">
+                    <p class="btn btn-primary btn-lg btn-custom-dw">Engage with IBM Open Source <b>developerWorks Open</b>
+                    </p>
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="container">
+        <div class="row">
             <div class="col-sm-12 col-md-12 col-lg-12">
-             <div id="wrapper">
-              <label for="search" class="col-lg-4 control-label search"><span>Search</span> 
+                <div id="wrapper">
+                    <label for="search" class="col-lg-4 control-label search"><span>Search</span> 
                   <input type="search" id="search" class="search-query span3 filter input-medium" placeholder="Our Repos...">
               </label>
-              <div id="repos" class="columns collapse-group">
-              </div>
-                <div id="showsomerepos" class="section-title show_less">
-                    <a class="title" href="">Show less</a>
+                    <div id="repos" class="columns collapse-group">
+                    </div>
+                    <div id="showsomerepos" class="section-title show_less">
+                        <a class="title" href="">Show less</a>
+                    </div>
+                    <div id="showallrepos" class="section-title show_more">
+                        <a class="title" href="#showall">Show more</a>
+                    </div>
+                    <div class="separator gap"></div>
                 </div>
-                <div id="showallrepos" class="section-title show_more">
-                    <a class="title" href="#showall">Show more</a>
-                </div>
-                 <div class="separator gap"></div>
-              </div> 
             </div>
-          </div>
         </div>
-        <hr>
-      </div>
     </div>
-  </div>
-  <footer>
-    <div class="container">
-      <p>&copy; Copyright IBM 2013-<span id="copyright-last-year"><script>document.write(new Date().getFullYear())</script></span></p>
+    <hr>
     </div>
-  </footer>
-</div> <!-- /container -->
+    </div>
+    </div>
+    <footer>
+        <div class="container">
+            <p>&copy; Copyright IBM 2013-<span id="copyright-last-year"><script>document.write(new Date().getFullYear())</script></span></p>
+        </div>
+    </footer>
+    </div>
+    <!-- /container -->
 
 
     <!-- Bootstrap core JavaScript
@@ -128,357 +140,362 @@ $(function() {
     <script type="text/javascript" src="js/strftime.js"></script>
     <script type="text/javascript" src="orgs.js"></script>
     <script type="text/javascript">
-    
-    var updated = [];
-    var allrepos = [];
-    
-    // go to http://thissite.example.com/#DEBUG to set DEBUG=true
-    var DEBUG = (window.location.hash === '#DEBUG');
-    var progress = 0;
-    
-    (function ($, undefined) {
-    	
-      var repoUrls = {
-      };
+        var updated = [];
+        var allrepos = [];
 
-      function repoUrl(repo) {
-        return repoUrls[repo.name] || repo.html_url;
-      }   
-      function addUpdated()
-      {
-      	$("#updated").empty();
-      	for (r=0; r < Math.min(4, updated.length); r++)
-      	{
-          repo = updated[r];
-          var $uitem = $("<div>").addClass("updated-card col-sm-5 col-md-4 col-lg-3");
-          var $item = $("<div>").addClass("card pin " + (repo.language || '').toLowerCase() + " "+repo.name.toLowerCase());
-          var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
-          $link.append($("<h4>").text(repo.name));
-          $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));
-          $item.append($("<p>").text(repo.description != null) ? repo.description : "");  
-          $item.appendTo($uitem);
-          $uitem.appendTo("#updated");
-        }
-        
-        var d = $("#updated").collapse({
-         toggle: true
-       });
+        // go to http://thissite.example.com/#DEBUG to set DEBUG=true
+        var DEBUG = (window.location.hash === '#DEBUG');
+        var progress = 0;
 
-      }
-      
-      function addAllRepos()
-      {
-      	$("#allrepos").empty();
-        var counter = 0;
-      	  if (window.location.hash === '#showall') {
-            for (r = 0; r < allrepos.length; r++)
-            {
-                repo = allrepos[r];
-                var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " "+repo.name.toLowerCase());
-                var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
-                $link.append($("<h4>").html(repo.name + "<div class='org'><a href='"+repo.owner.html_url+"'>("+repo.owner.login+")"));
-                $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));  
-                $item.append($("<p>").text(repo.description != null) ? repo.description : "");  
-                htag = "#allrepos";
-                $item.appendTo(htag);
-                counter++;
+        (function($, undefined) {
+
+            var repoUrls = {};
+
+            function repoUrl(repo) {
+                return repoUrls[repo.name] || repo.html_url;
             }
-            $(".nrepos").text("("+ counter +") Click 'Show less' to show only 20 repos");
-          }
-          else {
-            for (r = 0; r < Math.min(20, allrepos.length); r++)
-            {
-                repo = allrepos[r];
-                var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " "+repo.name.toLowerCase());
-                var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
-                $link.append($("<h4>").html(repo.name + "<div class='org'><a href='"+repo.owner.html_url+"'>("+repo.owner.login+")"));
-                $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));  
-                $item.append($("<p>").text(repo.description != null) ? repo.description : "");  
-                htag = "#allrepos";
-                $item.appendTo(htag);
-                counter++;
+
+            function addUpdated() {
+                $("#updated").empty();
+                for (r = 0; r < Math.min(4, updated.length); r++) {
+                    repo = updated[r];
+                    var $uitem = $("<div>").addClass("updated-card col-sm-5 col-md-4 col-lg-3");
+                    var $item = $("<div>").addClass("card pin " + (repo.language || '').toLowerCase() + " " + repo.name.toLowerCase());
+                    var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
+                    $link.append($("<h4>").text(repo.name));
+                    $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));
+                    $item.append($("<p>").text(repo.description != null) ? repo.description : "");
+                    $item.appendTo($uitem);
+                    $uitem.appendTo("#updated");
+                }
+
+                var d = $("#updated").collapse({
+                    toggle: true
+                });
+
             }
-            $(".nrepos").text("("+ counter +") Click 'Show more' to see other ("+(allrepos.length - counter)+") repos");
-        }
-        $("#allrepos").collapse({toggle: true})
-      }
 
-      function pushRepo(repos, org) 
-      {
-      	var left = repos; var right = allrepos;
-        var result  = [],
-        il      = 0,
-        ir      = 0;
-        
-        while (il < left.length && ir < right.length){
-         if (left[il].name.toLowerCase() < right[ir].name.toLowerCase()){
-           result.push(left[il++]);
-         } else {
-           result.push(right[ir++]);
-         }
-       }
-       
-       allrepos = result.concat(left.slice(il)).concat(right.slice(ir));
-     }      
-     
-     function mergeUpdated(repos)
-     {
-       var left = repos; var right = updated;
-       var result  = [],
-       il      = 0,
-       ir      = 0;
-       
-       while (il < left.length && ir < right.length){
-        if (left[il].pushed_at > right[ir].pushed_at){
-          result.push(left[il++]);
-        } else {
-          result.push(right[ir++]);
-        }
-      }
-      
-      updated = result.concat(left.slice(il)).concat(right.slice(ir));
-    }
-    
-    function addRepos(orgs, repos, page) {
-     var forks = [];
-     var org = orgs.name;
-     repos = repos || [];
-     page = page || 1;
-     reposcmd = orgs.type === "repo" ? "" : "/repos";
+            function addAllRepos() {
+                $("#allrepos").empty();
+                var counter = 0;
+                if (window.location.hash === '#showall') {
+                    for (r = 0; r < allrepos.length; r++) {
+                        repo = allrepos[r];
+                        var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " " + repo.name.toLowerCase());
+                        var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
+                        $link.append($("<h4>").html(repo.name + "<div class='org'><a href='" + repo.owner.html_url + "'>(" + repo.owner.login + ")"));
+                        $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));
+                        $item.append($("<p>").text(repo.description != null) ? repo.description : "");
+                        htag = "#allrepos";
+                        $item.appendTo(htag);
+                        counter++;
+                    }
+                    $(".nrepos").text("(" + counter + ") Click 'Show less' to show only 20 repos");
+                } else {
+                    for (r = 0; r < Math.min(20, allrepos.length); r++) {
+                        repo = allrepos[r];
+                        var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " " + repo.name.toLowerCase());
+                        var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
+                        $link.append($("<h4>").html(repo.name + "<div class='org'><a href='" + repo.owner.html_url + "'>(" + repo.owner.login + ")"));
+                        $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));
+                        $item.append($("<p>").text(repo.description != null) ? repo.description : "");
+                        htag = "#allrepos";
+                        $item.appendTo(htag);
+                        counter++;
+                    }
+                    $(".nrepos").text("(" + counter + ") Click 'Show more' to see other (" + (allrepos.length - counter) + ") repos");
+                }
+                $("#allrepos").collapse({
+                    toggle: true
+                })
+            }
 
-       // There are three supported request types: org, user and repo. Syntax differs.    
-       if((orgs.type !== 'org') && (orgs.type !== 'user') && (orgs.type !== 'repo')) {
-       	  console.log('** Unknown type “'+orgs.type+'” for org “'+org+'” — check “orgs.js” for typo.'); 
-       	  return;
-       }
-        
-       // These client tokens are for a dummy app, and there is no user specific 
-	   // information that we get, so all in all, pretty safe to expose this here.
-       var uri = "https://api.github.com/"+orgs.type+"s/"+org + reposcmd
-       + "?per_page=1000"
-       + "&client_id=1bafa09b6086eec7afb4"
-       + "&client_secret=7e6422a0a2e24f0d0ecb7521a63990b5758c9cc8";
-       $.getJSON(uri, function (result) {
-         if (!Array.isArray(result)) {
-           result = [].concat(result);
-         }
-         if (result && result.length > 0) {
-          repos = repos.concat(result);
+            function pushRepo(repos, org) {
+                var left = repos;
+                var right = allrepos;
+                var result = [],
+                    il = 0,
+                    ir = 0;
 
-          $(function () {
+                while (il < left.length && ir < right.length) {
+                    if (left[il].name.toLowerCase() < right[ir].name.toLowerCase()) {
+                        result.push(left[il++]);
+                    } else {
+                        result.push(right[ir++]);
+                    }
+                }
 
-            $.each(repos, function (i, repo) {
-              repo.pushed_at = new Date(repo.pushed_at);
-              if (repo.fork === true) {  // if this is a fork, save the index
-                forks.push(i);
-              }
+                allrepos = result.concat(left.slice(il)).concat(right.slice(ir));
+            }
+
+            function mergeUpdated(repos) {
+                var left = repos;
+                var right = updated;
+                var result = [],
+                    il = 0,
+                    ir = 0;
+
+                while (il < left.length && ir < right.length) {
+                    if (left[il].pushed_at > right[ir].pushed_at) {
+                        result.push(left[il++]);
+                    } else {
+                        result.push(right[ir++]);
+                    }
+                }
+
+                updated = result.concat(left.slice(il)).concat(right.slice(ir));
+            }
+
+            function addRepos(orgs, repos, page) {
+                var forks = [];
+                var org = orgs.name;
+                repos = repos || [];
+                page = page || 1;
+                reposcmd = orgs.type === "repo" ? "" : "/repos";
+
+                // There are three supported request types: org, user and repo. Syntax differs.    
+                if ((orgs.type !== 'org') && (orgs.type !== 'user') && (orgs.type !== 'repo')) {
+                    console.log('** Unknown type “' + orgs.type + '” for org “' + org + '” — check “orgs.js” for typo.');
+                    return;
+                }
+
+                // These client tokens are for a dummy app, and there is no user specific 
+                // information that we get, so all in all, pretty safe to expose this here.
+                var uri = "https://api.github.com/" + orgs.type + "s/" + org + reposcmd +
+                    "?per_page=1000" +
+                    "&client_id=1bafa09b6086eec7afb4" +
+                    "&client_secret=7e6422a0a2e24f0d0ecb7521a63990b5758c9cc8";
+                $.getJSON(uri, function(result) {
+                    if (!Array.isArray(result)) {
+                        result = [].concat(result);
+                    }
+                    if (result && result.length > 0) {
+                        repos = repos.concat(result);
+
+                        $(function() {
+
+                            $.each(repos, function(i, repo) {
+                                repo.pushed_at = new Date(repo.pushed_at);
+                                if (repo.fork === true) { // if this is a fork, save the index
+                                    forks.push(i);
+                                }
+                            });
+
+                            // remove forks from the view
+                            $.each(forks, function(i, forkindex) {
+                                var indextoremove = forkindex - i; // account for prior splices
+                                if (DEBUG) console.log('removing forked entry: ' + repos[indextoremove].full_name);
+                                repos.splice(indextoremove, 1);
+                            });
+
+                            // pre sort by how recently the repo was modified
+                            repos.sort(function(a, b) {
+                                if (a.pushed_at < b.pushed_at) return 1;
+                                if (b.pushed_at < a.pushed_at) return -1;
+                                return 0;
+                            });
+
+                            mergeUpdated(repos);
+
+                            repos.sort(function(a, b) {
+                                if (a.name.toLowerCase() > b.name.toLowerCase()) {
+                                    return 1;
+                                }
+                                if (b.name.toLowerCase() > a.name.toLowerCase()) {
+                                    return -1
+                                };
+                                return 0;
+                            });
+
+                            pushRepo(repos, org);
+
+                            // add 4 recently updated repos sorted by latest updates
+                            addUpdated();
+
+                            // add all other repos
+                            addAllRepos();
+
+                        });
+                    }
+                }).always(function() {
+                    updateProgress();
+                });
+            }
+
+            var formatPercent = function simplePercent(x) {
+                return (x * 100).toFixed(0);
+            }
+
+            var formatInt = function simpleNum(x) {
+                return x.toLocaleString();
+            }
+
+            if (window.hasOwnProperty('Intl')) {
+                var pctFormat = new Intl.NumberFormat([], {
+                    style: 'percent'
+                });
+                var decFormat = new Intl.NumberFormat([], {
+                    style: 'decimal',
+                    maximumFractionDigits: 0
+                });
+
+                formatPercent = function intlPercent(x) {
+                    return pctFormat.format(x);
+                };
+
+                formatInt = function intlNum(x) {
+                    return decFormat.format(x);
+                };
+            }
+
+            function updateProgress() {
+                progress++;
+
+                var fract = progress / orgs.length;
+
+                $progress.text(formatPercent(fract));
+
+                if (progress >= orgs.length) {
+                    $progress.delay(1000).fadeOut();
+                }
+            }
+
+            $("<div>").addClass("separator").appendTo("#wrapper");
+            var $sectiontitle = $("<div>").addClass("section-title").appendTo("#wrapper");
+            var $title = $("<span>").addClass('title').text("recent").appendTo($sectiontitle);
+            var $item = $("<div id='updated'>").addClass("columns section collapse");
+            $item.appendTo($sectiontitle);
+            var $twistie = $("<a data-toggle='collapse' data-target='#updated'>").addClass("twistie showdetails");
+            $twistie.appendTo($sectiontitle);
+
+            $("<div>").addClass("separator gap").appendTo("#wrapper");
+            var $sectiontitle = $("<div>").addClass("section-title").appendTo("#wrapper");
+            var $title = $("<span>").addClass('title').text("repos").appendTo($sectiontitle);
+            var $repos = $("<span>").addClass('nrepos').text("(0)").appendTo($title);
+            var $progress = $("<span>").addClass('loading').text("0 %").appendTo($title);
+            var $item = $("<div id='allrepos'>").addClass("columns section collapse");
+            $item.appendTo($sectiontitle);
+            var $twistie = $("<a data-toggle='collapse' data-target='#allrepos'>").addClass("twistie showdetails");
+            $twistie.appendTo($sectiontitle);
+
+            for (var r in orgs) {
+                addRepos(orgs[r]);
+            }
+
+            $("<div>").addClass("separator").appendTo("#wrapper");
+
+
+
+        })(jQuery);
+
+        $('#search').keyup(function() {
+            var val = $.trim($(this).val()).replace(/ +/g, ' ').toLowerCase();
+            $rows = $(".card")
+            $rows.show().filter(function() {
+                var text = $(this).text().replace(/\s+/g, ' ').toLowerCase();
+                return !~text.indexOf(val);
+            }).hide();
+
+            // update repo count here
+            n = $rows.length;
+            for (r in $rows) {
+                row = $rows[r];
+                style = row.style;
+                if (style && style.cssText && style.cssText.match("none")) {
+                    n--;
+                }
+
+            }
+
+            $rows = $(".updated-card");
+            $rows.show().filter(function() {
+                var text = $(this).text().replace(/\s+/g, ' ').toLowerCase();
+                return !~text.indexOf(val);
+            }).hide();
+
+            m = 4;
+            for (r in $rows) {
+                row = $rows[r];
+                style = row.style;
+                if (style && style.cssText && style.cssText.match("none")) {
+                    m--;
+                }
+
+            }
+
+            $(".nrepos").text("(" + (n - m) + ")");
+
+
+            // ---------------------------------
+            // Google Analytics Event Tracking
+            // 
+            // 
+            // usage: add the following attributes to links you want to track:
+            //   data-analytics-category=""    REQUIRED  String   Typically the object that was interacted with (e.g. button)
+            //   data-analytics-action=""      REQUIRED  String   The type of interaction (e.g. click)
+            //   data-analytics-label=""       OPTIONAL  String   Useful for categorizing events (e.g. nav buttons)
+            //   data-analytics-value=""       OPTIONAL  Integer  Values must be non-negative. Useful to pass counts (e.g. 4 times)
+            //
+            // Those are the suggested usages, but you can use the attributes how you want
+            // see https://developers.google.com/analytics/devguides/collection/analyticsjs/events for more details
+            // 
+            // EXAMPLE:
+            // <a href="http://ibm.com" data-analytics-category="Leadspace button" data-analytics-action="To ibm.com">Off you go!</a>
+            // ---------------------------------
+
+            $('body').on('click', 'a[data-analytics-category][data-analytics-action]', function(e) {
+
+                // No analytics? Bail.
+                if (!window.ga)
+                    return;
+
+                // for links to external sources, we need a tiny delay to have a little extra time to send to Google's servers before unload
+                // 200ms is about right for enough time
+                if (this.hostname && this.hostname !== location.hostname) {
+
+                    // Stop the link action
+                    e.preventDefault();
+
+                    // setTimeout callback is called in the window scope, so cache the url from the link now
+                    var url = this.href;
+
+                    // in 200ms, off you go
+                    setTimeout(function() {
+                        document.location = url;
+                    }, 200);
+                }
+
+                // make a new data object 
+                var $el = $(this),
+                    data = {
+                        'hitType': 'event'
+                    };
+
+                // category (required string)
+                data['eventCategory'] = $el.attr('data-analytics-category');
+
+                // action (required string)
+                data['eventAction'] = $el.attr('data-analytics-action');
+
+                // label (optional string)
+                if ($el.attr('data-analytics-label')) {
+                    data['eventLabel'] = $el.attr('data-analytics-label');
+                }
+
+                // value (optional int)
+                if ($el.attr('data-analytics-value')) {
+                    data['eventValue'] = parseInt($el.attr('data-analytics-value'));
+                }
+
+                // send the data
+                ga('send', data);
+
             });
-
-            // remove forks from the view
-            $.each(forks, function(i, forkindex) {
-              var indextoremove = forkindex - i; // account for prior splices
-              if(DEBUG) console.log('removing forked entry: ' + repos[indextoremove].full_name);
-              repos.splice(indextoremove,1);
-            });
-
-		// pre sort by how recently the repo was modified
-        repos.sort(function (a, b) {
-          if (a.pushed_at < b.pushed_at) return 1;
-          if (b.pushed_at < a.pushed_at) return -1;
-          return 0;
         });
 
-        mergeUpdated(repos);
-
-        repos.sort(function (a, b) {
-          if (a.name.toLowerCase() > b.name.toLowerCase()) {return 1;}
-          if (b.name.toLowerCase() > a.name.toLowerCase()) {return -1};
-          return 0;
-        });
-              
-        pushRepo(repos, org);
-        
-        // add 4 recently updated repos sorted by latest updates
-        addUpdated();
-              
-        // add all other repos
-        addAllRepos();
-
-      });
-        }
-      }).always(function() {
-        updateProgress();
-      });
-     }
-        
-      var formatPercent = function simplePercent(x) {
-        return (x * 100).toFixed(0);
-      }
-      
-      var formatInt = function simpleNum(x) {
-      	return x.toLocaleString();
-      }
-      
-      if(window.hasOwnProperty('Intl')) {
-      	var pctFormat = new Intl.NumberFormat([], {style: 'percent'});
-      	var decFormat = new Intl.NumberFormat([], {style: 'decimal', maximumFractionDigits:0 });
- 
-      	formatPercent = function intlPercent(x) {
-      		return pctFormat.format(x);
-      	};
- 
-      	formatInt = function intlNum(x) {
-      		return decFormat.format(x);
-      	};
-      }
-      
-      function updateProgress() {
-      	progress++;
-        
-        var fract = progress / orgs.length;
-      	
-        $progress.text(formatPercent(fract));
-      	
-      	if(progress >= orgs.length) {
-      		$progress.delay(1000).fadeOut();
-      	}
-      }
-     
-     $("<div>").addClass("separator").appendTo("#wrapper");
-     var $sectiontitle = $("<div>").addClass("section-title").appendTo("#wrapper");
-     var $title = $("<span>").addClass('title').text("recent").appendTo($sectiontitle);
-     var $item = $("<div id='updated'>").addClass("columns section collapse");
-     $item.appendTo($sectiontitle);
-     var $twistie = $("<a data-toggle='collapse' data-target='#updated'>").addClass("twistie showdetails");
-     $twistie.appendTo($sectiontitle);
-
-     $("<div>").addClass("separator gap").appendTo("#wrapper");
-     var $sectiontitle = $("<div>").addClass("section-title").appendTo("#wrapper");
-     var $title = $("<span>").addClass('title').text("repos").appendTo($sectiontitle);
-     var $repos = $("<span>").addClass('nrepos').text("(0)").appendTo($title);
-     var $progress = $("<span>").addClass('loading').text("0 %").appendTo($title);
-     var $item = $("<div id='allrepos'>").addClass("columns section collapse");
-     $item.appendTo($sectiontitle);
-     var $twistie = $("<a data-toggle='collapse' data-target='#allrepos'>").addClass("twistie showdetails");
-     $twistie.appendTo($sectiontitle);
-
-     for (var r in orgs) {
-         addRepos(orgs[r]);
-     }
-    
-     $("<div>").addClass("separator").appendTo("#wrapper");
-    
-
-
-  })(jQuery);
-  
-  $('#search').keyup(function() {
-    var val = $.trim($(this).val()).replace(/ +/g, ' ').toLowerCase();
-    $rows = $(".card")
-    $rows.show().filter(function() {
-      var text = $(this).text().replace(/\s+/g, ' ').toLowerCase();
-      return !~text.indexOf(val);
-    }).hide();
-    
-    // update repo count here
-    n = $rows.length;
-    for (r in $rows)
-    {
-    	row = $rows[r];
-    	style = row.style;
-    	if (style && style.cssText && style.cssText.match("none"))
-    	{
-    		n--;
-    	}
-
-    }
-    
-    $rows = $(".updated-card");
-    $rows.show().filter(function() {
-      var text = $(this).text().replace(/\s+/g, ' ').toLowerCase();
-      return !~text.indexOf(val);
-    }).hide();
-    
-    m = 4;
-    for (r in $rows)
-    {
-    	row = $rows[r];
-    	style = row.style;
-    	if (style && style.cssText && style.cssText.match("none"))
-    	{
-    		m--;
-    	}
-
-    }
-    
-    $(".nrepos").text("("+(n - m)+")");
-    
-
-    // ---------------------------------
-    // Google Analytics Event Tracking
-    // 
-    // 
-    // usage: add the following attributes to links you want to track:
-    //   data-analytics-category=""    REQUIRED  String   Typically the object that was interacted with (e.g. button)
-    //   data-analytics-action=""      REQUIRED  String   The type of interaction (e.g. click)
-    //   data-analytics-label=""       OPTIONAL  String   Useful for categorizing events (e.g. nav buttons)
-    //   data-analytics-value=""       OPTIONAL  Integer  Values must be non-negative. Useful to pass counts (e.g. 4 times)
-    //
-    // Those are the suggested usages, but you can use the attributes how you want
-    // see https://developers.google.com/analytics/devguides/collection/analyticsjs/events for more details
-    // 
-    // EXAMPLE:
-    // <a href="http://ibm.com" data-analytics-category="Leadspace button" data-analytics-action="To ibm.com">Off you go!</a>
-    // ---------------------------------
-    
-    $('body').on('click', 'a[data-analytics-category][data-analytics-action]', function(e){
-
-      // No analytics? Bail.
-      if (!window.ga)
-        return;
-      
-      // for links to external sources, we need a tiny delay to have a little extra time to send to Google's servers before unload
-      // 200ms is about right for enough time
-      if (this.hostname && this.hostname !== location.hostname) {
-        
-        // Stop the link action
-        e.preventDefault();
-        
-        // setTimeout callback is called in the window scope, so cache the url from the link now
-        var url = this.href;
-        
-        // in 200ms, off you go
-        setTimeout(function(){
-          document.location = url;        
-        },200);
-      }
-      
-      // make a new data object 
-      var $el = $(this), data = {'hitType': 'event'}; 
-          
-      // category (required string)
-      data['eventCategory'] =  $el.attr('data-analytics-category');
-      
-      // action (required string)
-      data['eventAction'] = $el.attr('data-analytics-action');
-      
-      // label (optional string)
-      if ($el.attr('data-analytics-label')) {
-          data['eventLabel'] = $el.attr('data-analytics-label');
-      }
-        
-      // value (optional int)
-      if ($el.attr('data-analytics-value')) {
-          data['eventValue'] = parseInt($el.attr('data-analytics-value'));
-      }
-
-      // send the data
-      ga('send', data);
-      
-    });
-});
-</script>
+    </script>
 
 
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -103,18 +103,20 @@
         <div class="row">
             <div class="col-sm-12 col-md-12 col-lg-12">
                 <div id="wrapper">
-                    <label for="search" class="col-lg-4 control-label search"><span>Search</span> 
-                  <input type="search" id="search" class="search-query span3 filter input-medium" placeholder="Our Repos...">
-              </label>
-                    <div id="repos" class="columns collapse-group">
+                    <div class="navigation">
+                        <div id="showsomerepos" class="section-title show_less">
+                            <a class="title" href="">Show less</a>
+                        </div>
+                        <label for="search" class="col-lg-4 control-label search"><span>Search</span> 
+                            <input type="search" id="search" class="search-query span3 filter input-medium" placeholder="Our Repos...">
+                        </label>
+                        <div id="showallrepos" class="section-title show_more">
+                            <a class="title" href="#showall">Show more</a>
+                        </div>
+                        <div class="separator gap"></div>
+                        <div id="repos" class="columns collapse-group">
+                        </div>
                     </div>
-                    <div id="showsomerepos" class="section-title show_less">
-                        <a class="title" href="">Show less</a>
-                    </div>
-                    <div id="showallrepos" class="section-title show_more">
-                        <a class="title" href="#showall">Show more</a>
-                    </div>
-                    <div class="separator gap"></div>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,32 @@
 ga('create', 'UA-41146412-2', 'ibm.github.io');
 ga('send', 'pageview');
 </script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script>
+$(function() {
 
+    $('#showallrepos a').click(function(e){
+        var url=$(this).attr('href');
+
+        window.location.href=url;// ## change url with hash
+        location.reload();       // ## reload page
+
+        e.preventDefault();      // ## prevent default click action 
+    })
+
+})     
+</script>
+  <script>  
+$(function() {
+
+    $('#showsomerepos a').click(function(e){
+        history.pushState("", document.title, window.location.pathname + window.location.search);
+        location.reload();
+        e.preventDefault();
+    })
+
+})     
+</script>
     
 
 </head>
@@ -72,6 +97,14 @@ ga('send', 'pageview');
               </label>
               <div id="repos" class="columns collapse-group">
               </div>
+                <div id="showsomerepos" class="section-title show_less">
+                    <a class="title" href="">Show less</a>
+                </div>
+                <div id="showallrepos" class="section-title show_more">
+                    <a class="title" href="#showall">Show more</a>
+                </div>
+                 <div class="separator gap"></div>
+              </div> 
             </div>
           </div>
         </div>
@@ -136,25 +169,38 @@ ga('send', 'pageview');
       function addAllRepos()
       {
       	$("#allrepos").empty();
-      	
-      	for (r=0; r < allrepos.length; r++)
-      	{
-          repo = allrepos[r];
-          var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 " + (repo.language || '').toLowerCase() + " "+repo.name.toLowerCase());
-          var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
-          $link.append($("<h4>").html(repo.name + "<div class='org'><a href='"+repo.owner.html_url+"'>("+repo.owner.login+")"));
-          $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));  
-          $item.append($("<p>").text(repo.description != null) ? repo.description : "");  
-          htag = "#allrepos";
-          $item.appendTo(htag);
+        var counter = 0;
+      	  if (window.location.hash === '#showall') {
+            for (r = 0; r < allrepos.length; r++)
+            {
+                repo = allrepos[r];
+                var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " "+repo.name.toLowerCase());
+                var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
+                $link.append($("<h4>").html(repo.name + "<div class='org'><a href='"+repo.owner.html_url+"'>("+repo.owner.login+")"));
+                $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));  
+                $item.append($("<p>").text(repo.description != null) ? repo.description : "");  
+                htag = "#allrepos";
+                $item.appendTo(htag);
+                counter++;
+            }
+            $(".nrepos").text("("+ counter +") Click 'Show less' to show only 20 repos");
+          }
+          else {
+            for (r = 0; r < Math.min(20, allrepos.length); r++)
+            {
+                repo = allrepos[r];
+                var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " "+repo.name.toLowerCase());
+                var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
+                $link.append($("<h4>").html(repo.name + "<div class='org'><a href='"+repo.owner.html_url+"'>("+repo.owner.login+")"));
+                $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));  
+                $item.append($("<p>").text(repo.description != null) ? repo.description : "");  
+                htag = "#allrepos";
+                $item.appendTo(htag);
+                counter++;
+            }
+            $(".nrepos").text("("+ counter +") Click 'Show more' to see other ("+(allrepos.length - counter)+") repos");
         }
-        
-        $(".nrepos").text("("+allrepos.length+")");
-        
-        var d = $("#allrepos").collapse({
-         toggle: true
-       });
-        
+        $("#allrepos").collapse({toggle: true})
       }
 
       function pushRepo(repos, org) 
@@ -200,14 +246,14 @@ ga('send', 'pageview');
      page = page || 1;
      reposcmd = orgs.type === "repo" ? "" : "/repos";
 
-	   // These client tokens are for a dummy app, and there is no user specific information that we get, so
-	   // all in all, pretty safe to expose this here.
-
-       // there are three supported request types: org, user and repo. Syntax differs.
+       // There are three supported request types: org, user and repo. Syntax differs.    
        if((orgs.type !== 'org') && (orgs.type !== 'user') && (orgs.type !== 'repo')) {
        	  console.log('** Unknown type “'+orgs.type+'” for org “'+org+'” — check “orgs.js” for typo.'); 
        	  return;
        }
+        
+       // These client tokens are for a dummy app, and there is no user specific 
+	   // information that we get, so all in all, pretty safe to expose this here.
        var uri = "https://api.github.com/"+orgs.type+"s/"+org + reposcmd
        + "?per_page=1000"
        + "&client_id=1bafa09b6086eec7afb4"
@@ -249,9 +295,13 @@ ga('send', 'pageview');
           if (b.name.toLowerCase() > a.name.toLowerCase()) {return -1};
           return 0;
         });
+              
         pushRepo(repos, org);
-
+        
+        // add 4 recently updated repos sorted by latest updates
         addUpdated();
+              
+        // add all other repos
         addAllRepos();
 
       });


### PR DESCRIPTION
## Description
- First things first: closes #53 
- This change does increase performance because he does not load 1000+ repos at visiting site
- If an user opens site he will see 4 recently updated repos and 20 other repos which is defined as default. I guess this should be default, because if you enter this site as mobile phone user which uses mobile data it gonna burn your data a little bit. I also edited how many repos we COULD show at the header.

> ~~https://user-images.githubusercontent.com/10914774/32388493-29a440c0-c0c8-11e7-84ae-22f6391ad401.png~~ (old)

![image](https://user-images.githubusercontent.com/10914774/32391612-f9917f6e-c0d2-11e7-867b-90d1d63ee933.png)

- User has the option to select `Show more` to show all repos. This causes that your browser puts a hash (`https://localhost/#showall`) after a reload, which was necessary because of javascript limitations.
- User also has option to revert this view with `Show less` which changes back to a view (also removes hash -> `https://localhost/`) of 20 repos
- Both buttons are matching the whole design and they also are optimized for mobile view (iPhone X as well, lol)
- Important note: If you search for a repo which is not shown if you only see 20 repos, you will not find that. In this case you have to select "Show more" which is working.

Mobile view (an URL because its gonna destroy my description)

> ~~https://user-images.githubusercontent.com/10914774/32388548-4eb44194-c0c8-11e7-8598-d50d728af459.png~~ (old)

> https://user-images.githubusercontent.com/10914774/32391556-cf0d19c4-c0d2-11e7-9301-079622f4d8ed.png


### Todo
- ~~Matching search bar with both buttons to make them look nicely in a row~~
- ~~Match mobile view again....~~
- ~~Changing text from `REPOS(20) CLICK 'SHOW MORE' TO SEE OTHER (1116) REPOS` to `SHOWING 20 REPOS. CLICK 'SHOW MORE' TO SEE OTHER 1116 REPOS`~~

@stevemart, what do you think about this?