### PR TITLE
Add SparkTC organization

### DIFF
--- a/orgs.js
+++ b/orgs.js
@@ -312,5 +312,10 @@ var orgs = [
       "name": "QISKit",
       "type": "org",
       "link": "https://www.qiskit.org/"
+  },
+  {
+      "name": "SparkTC",
+      "type": "org",
+      "link": "http://spark.tc/"
   }
 ];


### PR DESCRIPTION
Currently none of the [SparkTC](https://github.com/SparkTC/repositories) repositories are featured on [ibm.github.io](http://ibm.github.io/#showall).

On [IBM Code (developerWorks)](https://developer.ibm.com/code/open/projects/category/data/page/2/) you can at least find one SparkTC project: [Stocator](https://developer.ibm.com/code/open/projects/stocator/).

By adding ("registering") the SparkTC GitHub **organization** (https://github.com/SparkTC), as opposed to individual SparkTC **repositories**, all current and future public SparkTC repositories can be found on [ibm.github.io](http://ibm.github.io/#showall).
