### PR TITLE
Add Open Liberty org

### DIFF
--- a/orgs.js
+++ b/orgs.js
@@ -317,5 +317,10 @@ var orgs = [
       "name": "SparkTC",
       "type": "org",
       "link": "http://spark.tc/"
+  },
+  {
+      "name": "OpenLiberty",
+      "type": "org",
+      "link": "https://openliberty.io/"
   }
 ];


### PR DESCRIPTION
I'd like to add the Open Liberty Project Org to the list of IBM Github orgs.