### PR TITLE
The "IBM-Bluemix" org is now "IBM-Cloud"

### DIFF
--- a/orgs.js
+++ b/orgs.js
@@ -121,7 +121,7 @@ var orgs = [
       "type": "repo"
   },
   {
-      "name": "IBM-Bluemix",
+      "name": "IBM-Cloud",
       "type": "org"
   },
   {


### PR DESCRIPTION
The `IBM-Bluemix` org has moved. It is now `IBM-Cloud`, located at [https://github.com/IBM-Cloud/](https://github.com/IBM-Cloud/)