### PR TITLE
Scrollable Cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -422,7 +422,7 @@ label.search span {
 .card h4 {
     overflow: hidden;
     color: #00649c;
-    font-size: 1.25em;
+    /* font-size: 1.25em; */
     font-weight: 200;
     width: 100%;
     text-overflow: ellipsis;
@@ -430,10 +430,15 @@ label.search span {
     margin-bottom: 0;
 }
 
-.card h5 {
+.card p {
     color: #00b1ef;
-    font-size: 1em;
+    font-size: 0.85em;
     margin-top: 0;
+    padding: 0px;
+}
+
+.card small {
+    font-size: .85em;
 }
 
 .org {
@@ -508,14 +513,14 @@ label.search span {
     margin-bottom: 5px;
 }
 
-.pin p {
+/* .pin p {
     font: 12px/18px Arial, sans-serif;
     color: #333;
     font-size: 0.75em;
     height: 55px;
     overflow: hidden;
     margin: 0;
-}
+} */
 
 @media (min-width: 960px) {
     #columns {
@@ -537,22 +542,3 @@ label.search span {
     opacity: 0.4;
 }
 
-.scrollbar-outer {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    margin: 0;
-    box-sizing: content-box;
-    -moz-box-sizing: content-box;
-    -webkit-box-sizing: content-box;
-}
-
-.scrollbar-inner {
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    margin: 0;
-    box-sizing: content-box;
-    -moz-box-sizing: content-box;
-    -webkit-box-sizing: content-box;
-}

--- a/css/style.css
+++ b/css/style.css
@@ -293,8 +293,25 @@ div.news {
     margin: 5px;
     height: 160px;
     text-overflow: ellipsis;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
+
+::-webkit-scrollbar {
+    width: 5px;
+  }
+  
+  ::-webkit-scrollbar-track {
+    background: #f1f1f1; 
+  }
+  
+  ::-webkit-scrollbar-thumb {
+    background: #888; 
+  }
+  
+  ::-webkit-scrollbar-thumb:hover {
+    background: #555; 
+  }
 
 .filter {
     padding: 10px;

--- a/css/style.css
+++ b/css/style.css
@@ -297,7 +297,7 @@ div.news {
     overflow-y: auto;
 }
 
-::-webkit-scrollbar {
+  ::-webkit-scrollbar {
     width: 5px;
   }
   

--- a/js/repos.js
+++ b/js/repos.js
@@ -26,16 +26,12 @@ var progress = 0;
     function RenderRepo($index) {
         repo = allrepos[$index];
         var $item = $("<div>").addClass("card pin col-sm-5 col-md-4 col-lg-3 item " + (repo.language || '').toLowerCase() + " " + repo.name.toLowerCase());
-        var $scrollbarOuter = $("<div>").addClass("scrollbar-outer").appendTo($item);
-        var $scrollbarInner = $("<div>").addClass("scrollbar-inner").appendTo($scrollbarOuter);
-        var scrollbarOuter = document.createElement('div');
-        var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($scrollbarInner);
+        var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
         $link.append($("<h4>").html(repo.name + "<div class='org'><a href='" + repo.owner.html_url + "'>(" + repo.owner.login + ")"));
-        $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));
-        $scrollbarInner.append($("<p>").text(repo.description != null) ? repo.description : "");
+        $link.append($("<p>").text((repo.language != null) ? repo.language : ""));
+        $item.append($("<small>").text((repo.description != null) ? repo.description : ""));
         htag = "#allrepos";
         $item.appendTo(htag);
-        $scrollbarInner.css("padding-right", ($scrollbarInner[0].offsetWidth - $scrollbarInner[0].clientWidth));
         return;
     }
 
@@ -43,15 +39,13 @@ var progress = 0;
         repo = updated[$index];
         var $uitem = $("<div>").addClass("updated-card col-sm-5 col-md-4 col-lg-3");
         var $item = $("<div>").addClass("card pin " + (repo.language || '').toLowerCase() + " " + repo.name.toLowerCase());
-        var $scrollbarOuter = $("<div>").addClass("scrollbar-outer").appendTo($item);
-        var $scrollbarInner = $("<div>").addClass("scrollbar-inner").appendTo($scrollbarOuter);
-        var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($scrollbarInner);
+        var $link = $("<a>").attr("href", repoUrl(repo)).appendTo($item);
         $link.append($("<h4>").text(repo.name));
-        $link.append($("<h5>").text((repo.language != null) ? repo.language : ""));
-        $scrollbarInner.append($("<p>").text(repo.description != null) ? repo.description : "");
+        $link.append($("<p>").text((repo.language != null) ? repo.language : ""));
+        $item.append($("<small>").text((repo.description != null) ? repo.description : ""));
+        $("<small>").attr("style", "font-size: 10px;");
         $item.appendTo($uitem);
         $uitem.appendTo("#updated");
-        $scrollbarInner.css("padding-right", ($scrollbarInner[0].offsetWidth - $scrollbarInner[0].clientWidth));
     }
 
     function addUpdated() {


### PR DESCRIPTION
Hey there,

in the commit before I've removed the scrollable card implementation (done via js) because of the performance. The solution is much easier than that. Just changed the `overflow `handling to `overflow-y && -x` (x won't be ever the problem, so hidden) and Y as auto (only if needed).

The performance is pretty like after removing the other implementation.

Have fun.